### PR TITLE
Make struct fields public by default

### DIFF
--- a/NuklearDotNet/Draw.cs
+++ b/NuklearDotNet/Draw.cs
@@ -71,193 +71,193 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_scissor {
-		nk_command header;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
+		public nk_command header;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_line {
-		nk_command header;
-		ushort line_thickness;
-		nk_vec2i begin;
-		nk_vec2i end;
-		nk_color color;
+		public nk_command header;
+		public ushort line_thickness;
+		public nk_vec2i begin;
+		public nk_vec2i end;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_curve {
-		nk_command header;
-		ushort line_thickness;
-		nk_vec2i begin;
-		nk_vec2i end;
-		nk_vec2i ctrlA;
-		nk_vec2i ctrlB;
-		nk_color color;
+		public nk_command header;
+		public ushort line_thickness;
+		public nk_vec2i begin;
+		public nk_vec2i end;
+		public nk_vec2i ctrlA;
+		public nk_vec2i ctrlB;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_rect {
-		nk_command header;
-		ushort rounding;
-		ushort line_thickness;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
-		nk_color color;
+		public nk_command header;
+		public ushort rounding;
+		public ushort line_thickness;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_rect_filled {
-		nk_command header;
-		ushort rounding;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
-		nk_color color;
+		public nk_command header;
+		public ushort rounding;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_rect_multi_color {
-		nk_command header;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
-		nk_color left;
-		nk_color top;
-		nk_color bottom;
-		nk_color right;
+		public nk_command header;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
+		public nk_color left;
+		public nk_color top;
+		public nk_color bottom;
+		public nk_color right;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_triangle {
-		nk_command header;
-		ushort line_thickness;
-		nk_vec2i a;
-		nk_vec2i b;
-		nk_vec2i c;
-		nk_color color;
+		public nk_command header;
+		public ushort line_thickness;
+		public nk_vec2i a;
+		public nk_vec2i b;
+		public nk_vec2i c;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_triangle_filled {
-		nk_command header;
-		nk_vec2i a;
-		nk_vec2i b;
-		nk_vec2i c;
-		nk_color color;
+		public nk_command header;
+		public nk_vec2i a;
+		public nk_vec2i b;
+		public nk_vec2i c;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_circle {
-		nk_command header;
-		short x;
-		short y;
-		ushort line_thickness;
-		ushort w;
-		ushort h;
-		nk_color color;
+		public nk_command header;
+		public short x;
+		public short y;
+		public ushort line_thickness;
+		public ushort w;
+		public ushort h;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_circle_filled {
-		nk_command header;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
-		nk_color color;
+		public nk_command header;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_command_arc {
-		nk_command header;
-		short cx;
-		short cy;
-		ushort r;
-		ushort line_thickness;
-		fixed float a[2];
-		nk_color color;
+		public nk_command header;
+		public short cx;
+		public short cy;
+		public ushort r;
+		public ushort line_thickness;
+		public fixed float a[2];
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_command_arc_filled {
-		nk_command header;
-		short cx;
-		short cy;
-		ushort r;
-		fixed float a[2];
-		nk_color color;
+		public nk_command header;
+		public short cx;
+		public short cy;
+		public ushort r;
+		public fixed float a[2];
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_command_polygon {
-		nk_command header;
-		nk_color color;
-		ushort line_thickness;
-		ushort point_count;
-		nk_vec2i firstPoint;  /* (fixed?) struct nk_vec2i points[1]; /* ????? * */
+		public nk_command header;
+		public nk_color color;
+		public ushort line_thickness;
+		public ushort point_count;
+		public nk_vec2i firstPoint;  /* (fixed?) struct nk_vec2i points[1]; /* ????? * */
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_command_polygon_filled {
-		nk_command header;
-		nk_color color;
-		ushort point_count;
-		nk_vec2i firstPoint;
+		public nk_command header;
+		public nk_color color;
+		public ushort point_count;
+		public nk_vec2i firstPoint;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_polyline {
-		nk_command header;
-		nk_color color;
-		ushort line_thickness;
-		ushort point_count;
-		nk_vec2i firstPoint;
+		public nk_command header;
+		public nk_color color;
+		public ushort line_thickness;
+		public ushort point_count;
+		public nk_vec2i firstPoint;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_image {
-		nk_command header;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
-		nk_image img;
-		nk_color col;
+		public nk_command header;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
+		public nk_image img;
+		public nk_color col;
 	}
 
 	public delegate void nk_command_custom_callback(IntPtr canvas, short x, short y, ushort w, ushort h, nk_handle callback_data);
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_command_custom {
-		nk_command header;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
-		nk_handle callback_data;
-		nk_command_custom_callback callback;
+		public nk_command header;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
+		public nk_handle callback_data;
+		public nk_command_custom_callback callback;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_command_text {
-		nk_command header;
-		nk_user_font* font;
-		nk_color background;
-		nk_color foreground;
-		short x;
-		short y;
-		ushort w;
-		ushort h;
-		float height;
-		int length;
-		byte stringFirstByte;
+		public nk_command header;
+		public nk_user_font* font;
+		public nk_color background;
+		public nk_color foreground;
+		public short x;
+		public short y;
+		public ushort w;
+		public ushort h;
+		public float height;
+		public int length;
+		public byte stringFirstByte;
 	}
 
 	public enum nk_command_clipping {
@@ -267,13 +267,13 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_command_buffer {
-		nk_buffer* baseBuf;
-		nk_rect clip;
-		int use_clipping;
-		nk_handle userdata;
-		IntPtr begin_nksize;
-		IntPtr end_nksize;
-		IntPtr last_nksize;
+		public nk_buffer* baseBuf;
+		public nk_rect clip;
+		public int use_clipping;
+		public nk_handle userdata;
+		public IntPtr begin_nksize;
+		public IntPtr end_nksize;
+		public IntPtr last_nksize;
 	}
 
 	/* nk_draw_index -> nk_ushort */
@@ -344,26 +344,26 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_draw_list {
-		nk_rect clip_rect;
-		fixed long circle_vtx_CastMeToVec2[12];
-		nk_convert_config config;
+		public nk_rect clip_rect;
+		public fixed long circle_vtx_CastMeToVec2[12];
+		public nk_convert_config config;
 
-		nk_buffer* buffer;
-		nk_buffer* vertices;
-		nk_buffer* elements;
+		public nk_buffer* buffer;
+		public nk_buffer* vertices;
+		public nk_buffer* elements;
 
-		uint element_count;
-		uint vertex_count;
-		uint cmd_count;
-		IntPtr cmd_offset_nksize;
+		public uint element_count;
+		public uint vertex_count;
+		public uint cmd_count;
+		public IntPtr cmd_offset_nksize;
 
-		uint path_count;
-		uint path_offset;
+		public uint path_count;
+		public uint path_offset;
 
-		nk_anti_aliasing line_AA;
-		nk_anti_aliasing shape_AA;
+		public nk_anti_aliasing line_AA;
+		public nk_anti_aliasing shape_AA;
 
-		nk_handle userdata;
+		public nk_handle userdata;
 	}
 
 	public static unsafe partial class Nuklear {

--- a/NuklearDotNet/Font.cs
+++ b/NuklearDotNet/Font.cs
@@ -8,12 +8,12 @@ using System.Threading.Tasks;
 namespace NuklearDotNet {
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_user_font_glyph {
-		nk_vec2 u;
-		nk_vec2 v;
-		nk_vec2 offset;
-		float width;
-		float height;
-		float xadvance;
+		public nk_vec2 u;
+		public nk_vec2 v;
+		public nk_vec2 offset;
+		public float width;
+		public float height;
+		public float xadvance;
 	}
 
 	public unsafe delegate float nk_text_width_f(nk_handle handle, float h, byte* s, int len);
@@ -21,11 +21,11 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_user_font {
-		nk_handle userdata;
-		float height;
-		IntPtr widthfun_nkTextWidthF;
-		IntPtr queryfun_nkQueryFontGlyphF;
-		nk_handle texture;
+		public nk_handle userdata;
+		public float height;
+		public IntPtr widthfun_nkTextWidthF;
+		public IntPtr queryfun_nkQueryFontGlyphF;
+		public nk_handle texture;
 	}
 
 	public enum nk_font_coord_type {
@@ -35,50 +35,50 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_baked_font {
-		float height;
-		float ascent;
-		float descent;
-		uint glyph_offset;
-		uint glyph_count;
-		uint* ranges;
+		public float height;
+		public float ascent;
+		public float descent;
+		public uint glyph_offset;
+		public uint glyph_count;
+		public uint* ranges;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_font_config {
-		nk_font_config* next;
-		IntPtr ttf_blob;
-		IntPtr ttf_size;
-		byte ttf_data_owned_by_atlas;
-		byte merge_mode;
-		byte pixel_snap;
-		byte oversample_v;
-		byte oversample_h;
+		public nk_font_config* next;
+		public IntPtr ttf_blob;
+		public IntPtr ttf_size;
+		public byte ttf_data_owned_by_atlas;
+		public byte merge_mode;
+		public byte pixel_snap;
+		public byte oversample_v;
+		public byte oversample_h;
 		fixed byte padding[3];
-		float size;
-		nk_font_coord_type coord_type;
-		nk_vec2 spacing;
-		uint* range;
-		nk_baked_font* font;
-		uint fallback_glyph;
+		public float size;
+		public nk_font_coord_type coord_type;
+		public nk_vec2 spacing;
+		public uint* range;
+		public nk_baked_font* font;
+		public uint fallback_glyph;
 
-		nk_font_config* n;
-		nk_font_config* p;
+		public nk_font_config* n;
+		public nk_font_config* p;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_font_glyph {
-		uint codepoint;
-		float xadvance;
-		float x0;
-		float y0;
-		float x1;
-		float y1;
-		float w;
-		float h;
-		float u0;
-		float v0;
-		float u1;
-		float v1;
+		public uint codepoint;
+		public float xadvance;
+		public float x0;
+		public float y0;
+		public float x1;
+		public float y1;
+		public float w;
+		public float h;
+		public float u0;
+		public float v0;
+		public float u1;
+		public float v1;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]

--- a/NuklearDotNet/General.cs
+++ b/NuklearDotNet/General.cs
@@ -13,30 +13,30 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_color {
-		byte r;
-		byte g;
-		byte b;
-		byte a;
+		public byte r;
+		public byte g;
+		public byte b;
+		public byte a;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_colorf {
-		float r;
-		float g;
-		float b;
-		float a;
+		public float r;
+		public float g;
+		public float b;
+		public float a;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_vec2 {
-		float x;
-		float y;
+		public float x;
+		public float y;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_vec2i {
-		short x;
-		short y;
+		public short x;
+		public short y;
 	}
 
 
@@ -58,19 +58,19 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_recti {
-		short x;
-		short y;
-		short w;
-		short h;
+		public short x;
+		public short y;
+		public short w;
+		public short h;
 	}
 
 	[StructLayout(LayoutKind.Explicit)]
 	public unsafe struct nk_glyph {
 		[FieldOffset(0)]
-		fixed byte bytes[4];
+		public fixed byte bytes[4];
 
 		[FieldOffset(0)]
-		int glyph;
+		public int glyph;
 	}
 
 	[StructLayout(LayoutKind.Explicit)]
@@ -83,23 +83,23 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_image {
-		nk_handle handle;
-		ushort w;
-		ushort h;
-		fixed ushort region[4];
+		public nk_handle handle;
+		public ushort w;
+		public ushort h;
+		public fixed ushort region[4];
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_cursor {
-		nk_image img;
-		nk_vec2 size;
-		nk_vec2 offset;
+		public nk_image img;
+		public nk_vec2 size;
+		public nk_vec2 offset;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_scroll {
-		uint x;
-		uint y;
+		public uint x;
+		public uint y;
 	}
 
 	/* ... */

--- a/NuklearDotNet/Init.cs
+++ b/NuklearDotNet/Init.cs
@@ -42,12 +42,12 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_memory_status {
-		IntPtr memory;
-		uint type;
-		IntPtr size;
-		IntPtr allocated;
-		IntPtr needed;
-		IntPtr calls;
+		public IntPtr memory;
+		public uint type;
+		public IntPtr size;
+		public IntPtr allocated;
+		public IntPtr needed;
+		public IntPtr calls;
 	}
 
 	public enum nk_allocation_type : int {
@@ -89,318 +89,318 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_style_item_element {
-		nk_style_item* address;
-		nk_style_item old_value;
+		public nk_style_item* address;
+		public nk_style_item old_value;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_float_element {
-		float* address;
-		float old_value;
+		public float* address;
+		public float old_value;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_vec2_element {
-		nk_vec2* address;
-		nk_vec2 old_value;
+		public nk_vec2* address;
+		public nk_vec2 old_value;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_flags_element {
-		uint* address_nkflags;
-		uint old_value_nkflags;
+		public uint* address_nkflags;
+		public uint old_value_nkflags;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_color_element {
-		nk_color* address;
-		nk_color old_value;
+		public nk_color* address;
+		public nk_color old_value;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_user_font_element {
-		nk_user_font* address;
-		nk_user_font* old_value;
+		public nk_user_font* address;
+		public nk_user_font* old_value;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_button_behavior_element {
-		nk_button_behavior* address;
-		nk_button_behavior old_value;
+		public nk_button_behavior* address;
+		public nk_button_behavior old_value;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_style_item {
-		int head;
-		nk_config_stack_style_item_element element0;
-		nk_config_stack_style_item_element element1;
-		nk_config_stack_style_item_element element2;
-		nk_config_stack_style_item_element element3;
-		nk_config_stack_style_item_element element4;
-		nk_config_stack_style_item_element element5;
-		nk_config_stack_style_item_element element6;
-		nk_config_stack_style_item_element element7;
-		nk_config_stack_style_item_element element8;
-		nk_config_stack_style_item_element element9;
-		nk_config_stack_style_item_element element10;
-		nk_config_stack_style_item_element element11;
-		nk_config_stack_style_item_element element12;
-		nk_config_stack_style_item_element element13;
-		nk_config_stack_style_item_element element14;
-		nk_config_stack_style_item_element element15;
+		public int head;
+		public nk_config_stack_style_item_element element0;
+		public nk_config_stack_style_item_element element1;
+		public nk_config_stack_style_item_element element2;
+		public nk_config_stack_style_item_element element3;
+		public nk_config_stack_style_item_element element4;
+		public nk_config_stack_style_item_element element5;
+		public nk_config_stack_style_item_element element6;
+		public nk_config_stack_style_item_element element7;
+		public nk_config_stack_style_item_element element8;
+		public nk_config_stack_style_item_element element9;
+		public nk_config_stack_style_item_element element10;
+		public nk_config_stack_style_item_element element11;
+		public nk_config_stack_style_item_element element12;
+		public nk_config_stack_style_item_element element13;
+		public nk_config_stack_style_item_element element14;
+		public nk_config_stack_style_item_element element15;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_float {
-		int head;
-		nk_config_stack_float_element element0;
-		nk_config_stack_float_element element1;
-		nk_config_stack_float_element element2;
-		nk_config_stack_float_element element3;
-		nk_config_stack_float_element element4;
-		nk_config_stack_float_element element5;
-		nk_config_stack_float_element element6;
-		nk_config_stack_float_element element7;
-		nk_config_stack_float_element element8;
-		nk_config_stack_float_element element9;
-		nk_config_stack_float_element element10;
-		nk_config_stack_float_element element11;
-		nk_config_stack_float_element element12;
-		nk_config_stack_float_element element13;
-		nk_config_stack_float_element element14;
-		nk_config_stack_float_element element15;
-		nk_config_stack_float_element element16;
-		nk_config_stack_float_element element17;
-		nk_config_stack_float_element element18;
-		nk_config_stack_float_element element19;
-		nk_config_stack_float_element element20;
-		nk_config_stack_float_element element21;
-		nk_config_stack_float_element element22;
-		nk_config_stack_float_element element23;
-		nk_config_stack_float_element element24;
-		nk_config_stack_float_element element25;
-		nk_config_stack_float_element element26;
-		nk_config_stack_float_element element27;
-		nk_config_stack_float_element element28;
-		nk_config_stack_float_element element29;
-		nk_config_stack_float_element element30;
-		nk_config_stack_float_element element31;
+		public int head;
+		public nk_config_stack_float_element element0;
+		public nk_config_stack_float_element element1;
+		public nk_config_stack_float_element element2;
+		public nk_config_stack_float_element element3;
+		public nk_config_stack_float_element element4;
+		public nk_config_stack_float_element element5;
+		public nk_config_stack_float_element element6;
+		public nk_config_stack_float_element element7;
+		public nk_config_stack_float_element element8;
+		public nk_config_stack_float_element element9;
+		public nk_config_stack_float_element element10;
+		public nk_config_stack_float_element element11;
+		public nk_config_stack_float_element element12;
+		public nk_config_stack_float_element element13;
+		public nk_config_stack_float_element element14;
+		public nk_config_stack_float_element element15;
+		public nk_config_stack_float_element element16;
+		public nk_config_stack_float_element element17;
+		public nk_config_stack_float_element element18;
+		public nk_config_stack_float_element element19;
+		public nk_config_stack_float_element element20;
+		public nk_config_stack_float_element element21;
+		public nk_config_stack_float_element element22;
+		public nk_config_stack_float_element element23;
+		public nk_config_stack_float_element element24;
+		public nk_config_stack_float_element element25;
+		public nk_config_stack_float_element element26;
+		public nk_config_stack_float_element element27;
+		public nk_config_stack_float_element element28;
+		public nk_config_stack_float_element element29;
+		public nk_config_stack_float_element element30;
+		public nk_config_stack_float_element element31;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_vec2 {
-		int head;
-		nk_config_stack_vec2_element element0;
-		nk_config_stack_vec2_element element1;
-		nk_config_stack_vec2_element element2;
-		nk_config_stack_vec2_element element3;
-		nk_config_stack_vec2_element element4;
-		nk_config_stack_vec2_element element5;
-		nk_config_stack_vec2_element element6;
-		nk_config_stack_vec2_element element7;
-		nk_config_stack_vec2_element element8;
-		nk_config_stack_vec2_element element9;
-		nk_config_stack_vec2_element element10;
-		nk_config_stack_vec2_element element11;
-		nk_config_stack_vec2_element element12;
-		nk_config_stack_vec2_element element13;
-		nk_config_stack_vec2_element element14;
-		nk_config_stack_vec2_element element15;
+		public int head;
+		public nk_config_stack_vec2_element element0;
+		public nk_config_stack_vec2_element element1;
+		public nk_config_stack_vec2_element element2;
+		public nk_config_stack_vec2_element element3;
+		public nk_config_stack_vec2_element element4;
+		public nk_config_stack_vec2_element element5;
+		public nk_config_stack_vec2_element element6;
+		public nk_config_stack_vec2_element element7;
+		public nk_config_stack_vec2_element element8;
+		public nk_config_stack_vec2_element element9;
+		public nk_config_stack_vec2_element element10;
+		public nk_config_stack_vec2_element element11;
+		public nk_config_stack_vec2_element element12;
+		public nk_config_stack_vec2_element element13;
+		public nk_config_stack_vec2_element element14;
+		public nk_config_stack_vec2_element element15;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_flags {
-		int head;
-		nk_config_stack_flags_element element0;
-		nk_config_stack_flags_element element1;
-		nk_config_stack_flags_element element2;
-		nk_config_stack_flags_element element3;
-		nk_config_stack_flags_element element4;
-		nk_config_stack_flags_element element5;
-		nk_config_stack_flags_element element6;
-		nk_config_stack_flags_element element7;
-		nk_config_stack_flags_element element8;
-		nk_config_stack_flags_element element9;
-		nk_config_stack_flags_element element10;
-		nk_config_stack_flags_element element11;
-		nk_config_stack_flags_element element12;
-		nk_config_stack_flags_element element13;
-		nk_config_stack_flags_element element14;
-		nk_config_stack_flags_element element15;
-		nk_config_stack_flags_element element16;
-		nk_config_stack_flags_element element17;
-		nk_config_stack_flags_element element18;
-		nk_config_stack_flags_element element19;
-		nk_config_stack_flags_element element20;
-		nk_config_stack_flags_element element21;
-		nk_config_stack_flags_element element22;
-		nk_config_stack_flags_element element23;
-		nk_config_stack_flags_element element24;
-		nk_config_stack_flags_element element25;
-		nk_config_stack_flags_element element26;
-		nk_config_stack_flags_element element27;
-		nk_config_stack_flags_element element28;
-		nk_config_stack_flags_element element29;
-		nk_config_stack_flags_element element30;
-		nk_config_stack_flags_element element31;
+		public int head;
+		public nk_config_stack_flags_element element0;
+		public nk_config_stack_flags_element element1;
+		public nk_config_stack_flags_element element2;
+		public nk_config_stack_flags_element element3;
+		public nk_config_stack_flags_element element4;
+		public nk_config_stack_flags_element element5;
+		public nk_config_stack_flags_element element6;
+		public nk_config_stack_flags_element element7;
+		public nk_config_stack_flags_element element8;
+		public nk_config_stack_flags_element element9;
+		public nk_config_stack_flags_element element10;
+		public nk_config_stack_flags_element element11;
+		public nk_config_stack_flags_element element12;
+		public nk_config_stack_flags_element element13;
+		public nk_config_stack_flags_element element14;
+		public nk_config_stack_flags_element element15;
+		public nk_config_stack_flags_element element16;
+		public nk_config_stack_flags_element element17;
+		public nk_config_stack_flags_element element18;
+		public nk_config_stack_flags_element element19;
+		public nk_config_stack_flags_element element20;
+		public nk_config_stack_flags_element element21;
+		public nk_config_stack_flags_element element22;
+		public nk_config_stack_flags_element element23;
+		public nk_config_stack_flags_element element24;
+		public nk_config_stack_flags_element element25;
+		public nk_config_stack_flags_element element26;
+		public nk_config_stack_flags_element element27;
+		public nk_config_stack_flags_element element28;
+		public nk_config_stack_flags_element element29;
+		public nk_config_stack_flags_element element30;
+		public nk_config_stack_flags_element element31;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_color {
-		int head;
-		nk_config_stack_color_element element0;
-		nk_config_stack_color_element element1;
-		nk_config_stack_color_element element2;
-		nk_config_stack_color_element element3;
-		nk_config_stack_color_element element4;
-		nk_config_stack_color_element element5;
-		nk_config_stack_color_element element6;
-		nk_config_stack_color_element element7;
-		nk_config_stack_color_element element8;
-		nk_config_stack_color_element element9;
-		nk_config_stack_color_element element10;
-		nk_config_stack_color_element element11;
-		nk_config_stack_color_element element12;
-		nk_config_stack_color_element element13;
-		nk_config_stack_color_element element14;
-		nk_config_stack_color_element element15;
-		nk_config_stack_color_element element16;
-		nk_config_stack_color_element element17;
-		nk_config_stack_color_element element18;
-		nk_config_stack_color_element element19;
-		nk_config_stack_color_element element20;
-		nk_config_stack_color_element element21;
-		nk_config_stack_color_element element22;
-		nk_config_stack_color_element element23;
-		nk_config_stack_color_element element24;
-		nk_config_stack_color_element element25;
-		nk_config_stack_color_element element26;
-		nk_config_stack_color_element element27;
-		nk_config_stack_color_element element28;
-		nk_config_stack_color_element element29;
-		nk_config_stack_color_element element30;
-		nk_config_stack_color_element element31;
+		public int head;
+		public nk_config_stack_color_element element0;
+		public nk_config_stack_color_element element1;
+		public nk_config_stack_color_element element2;
+		public nk_config_stack_color_element element3;
+		public nk_config_stack_color_element element4;
+		public nk_config_stack_color_element element5;
+		public nk_config_stack_color_element element6;
+		public nk_config_stack_color_element element7;
+		public nk_config_stack_color_element element8;
+		public nk_config_stack_color_element element9;
+		public nk_config_stack_color_element element10;
+		public nk_config_stack_color_element element11;
+		public nk_config_stack_color_element element12;
+		public nk_config_stack_color_element element13;
+		public nk_config_stack_color_element element14;
+		public nk_config_stack_color_element element15;
+		public nk_config_stack_color_element element16;
+		public nk_config_stack_color_element element17;
+		public nk_config_stack_color_element element18;
+		public nk_config_stack_color_element element19;
+		public nk_config_stack_color_element element20;
+		public nk_config_stack_color_element element21;
+		public nk_config_stack_color_element element22;
+		public nk_config_stack_color_element element23;
+		public nk_config_stack_color_element element24;
+		public nk_config_stack_color_element element25;
+		public nk_config_stack_color_element element26;
+		public nk_config_stack_color_element element27;
+		public nk_config_stack_color_element element28;
+		public nk_config_stack_color_element element29;
+		public nk_config_stack_color_element element30;
+		public nk_config_stack_color_element element31;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_user_font {
-		int head;
-		nk_config_stack_user_font_element element0;
-		nk_config_stack_user_font_element element1;
-		nk_config_stack_user_font_element element2;
-		nk_config_stack_user_font_element element3;
-		nk_config_stack_user_font_element element4;
-		nk_config_stack_user_font_element element5;
-		nk_config_stack_user_font_element element6;
-		nk_config_stack_user_font_element element7;
+		public int head;
+		public nk_config_stack_user_font_element element0;
+		public nk_config_stack_user_font_element element1;
+		public nk_config_stack_user_font_element element2;
+		public nk_config_stack_user_font_element element3;
+		public nk_config_stack_user_font_element element4;
+		public nk_config_stack_user_font_element element5;
+		public nk_config_stack_user_font_element element6;
+		public nk_config_stack_user_font_element element7;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_config_stack_button_behavior {
-		int head;
-		nk_config_stack_button_behavior_element element0;
-		nk_config_stack_button_behavior_element element1;
-		nk_config_stack_button_behavior_element element2;
-		nk_config_stack_button_behavior_element element3;
-		nk_config_stack_button_behavior_element element4;
-		nk_config_stack_button_behavior_element element5;
-		nk_config_stack_button_behavior_element element6;
-		nk_config_stack_button_behavior_element element7;
+		public int head;
+		public nk_config_stack_button_behavior_element element0;
+		public nk_config_stack_button_behavior_element element1;
+		public nk_config_stack_button_behavior_element element2;
+		public nk_config_stack_button_behavior_element element3;
+		public nk_config_stack_button_behavior_element element4;
+		public nk_config_stack_button_behavior_element element5;
+		public nk_config_stack_button_behavior_element element6;
+		public nk_config_stack_button_behavior_element element7;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_configuration_stacks {
-		nk_config_stack_style_item style_items;
-		nk_config_stack_float floats;
-		nk_config_stack_vec2 vectors;
-		nk_config_stack_flags flags;
-		nk_config_stack_color colors;
-		nk_config_stack_user_font fonts;
-		nk_config_stack_button_behavior button_behaviors;
+		public nk_config_stack_style_item style_items;
+		public nk_config_stack_float floats;
+		public nk_config_stack_vec2 vectors;
+		public nk_config_stack_flags flags;
+		public nk_config_stack_color colors;
+		public nk_config_stack_user_font fonts;
+		public nk_config_stack_button_behavior button_behaviors;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_table {
-		uint seq;
-		uint size;
+		public uint seq;
+		public uint size;
 		// nk_hash keys[(((((sizeof(struct nk_window)) < (sizeof(struct nk_panel)) ? (sizeof(struct nk_panel)) : (sizeof(struct nk_window))) / sizeof(nk_uint))) / 2)];
 		// nk_window: c# size 472, C size 472
 		// nk_panel: c# size 448, C size 448
 		// => nk_hash keys[(((472 < 448 ? 448 : 472) / 4) / 2)]
 		// => nk_hash keys[((472 / 4) / 2)]
 		// => nk_hash keys[472 / 8]
-		fixed uint keys_nkhash[472 / 8];
+		public fixed uint keys_nkhash[472 / 8];
 		// nk_uint values[(((((sizeof(struct nk_window)) < (sizeof(struct nk_panel)) ? (sizeof(struct nk_panel)) : (sizeof(struct nk_window))) / sizeof(nk_uint))) / 2)];
-		fixed uint values[472 / 8];
-		nk_table* next;
-		nk_table* prev;
+		public fixed uint values[472 / 8];
+		public nk_table* next;
+		public nk_table* prev;
 	}
 
 	[StructLayout(LayoutKind.Explicit)]
 	public unsafe struct nk_page_data {
 		[FieldOffset(0)]
-		nk_table tbl;
+		public nk_table tbl;
 		[FieldOffset(0)]
-		nk_panel pan;
+		public nk_panel pan;
 		[FieldOffset(0)]
-		nk_window win;
+		public nk_window win;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_page_element {
-		nk_page_data data;
-		nk_page_element* next;
-		nk_page_element* prev;
+		public nk_page_data data;
+		public nk_page_element* next;
+		public nk_page_element* prev;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_page {
-		uint size;
-		nk_page* next;
-		nk_page_element win0;
+		public uint size;
+		public nk_page* next;
+		public nk_page_element win0;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_pool {
-		nk_allocator alloc;
-		nk_allocation_type type;
-		uint page_count;
-		nk_page* pages;
-		nk_page_element* freelist;
-		uint capacity;
-		IntPtr size_nksize;
-		IntPtr cap_nksize;
+		public nk_allocator alloc;
+		public nk_allocation_type type;
+		public uint page_count;
+		public nk_page* pages;
+		public nk_page_element* freelist;
+		public uint capacity;
+		public IntPtr size_nksize;
+		public IntPtr cap_nksize;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_context {
-		nk_input input;
-		nk_style style;
-		nk_buffer memory;
-		nk_clipboard clip;
-		uint last_widget_state_nkflags;
-		nk_button_behavior button_behavior;
-		nk_configuration_stacks stacks;
-		float delta_time_Seconds;
+		public nk_input input;
+		public nk_style style;
+		public nk_buffer memory;
+		public nk_clipboard clip;
+		public uint last_widget_state_nkflags;
+		public nk_button_behavior button_behavior;
+		public nk_configuration_stacks stacks;
+		public float delta_time_Seconds;
 
-		nk_draw_list draw_list;
+		public nk_draw_list draw_list;
 
-		nk_handle userdata;
+		public nk_handle userdata;
 
-		nk_text_edit text_edit;
+		public nk_text_edit text_edit;
 
-		nk_command_buffer overlay;
+		public nk_command_buffer overlay;
 
-		int build;
-		int use_pool;
-		nk_pool pool;
-		nk_window* begin;
-		nk_window* end;
-		nk_window* active;
-		nk_window* current;
-		nk_page_element* freelist;
-		uint count;
-		uint seq;
+		public int build;
+		public int use_pool;
+		public nk_pool pool;
+		public nk_window* begin;
+		public nk_window* end;
+		public nk_window* active;
+		public nk_window* current;
+		public nk_page_element* freelist;
+		public uint count;
+		public uint seq;
 	}
 
 	public static unsafe partial class Nuklear {

--- a/NuklearDotNet/Input.cs
+++ b/NuklearDotNet/Input.cs
@@ -52,46 +52,46 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_mouse_button {
-		int down;
-		uint clicked;
-		nk_vec2 clicked_pos;
+		public int down;
+		public uint clicked;
+		public nk_vec2 clicked_pos;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_mouse {
 		/* fixed nk_mouse_button buttons[(int)(nk_buttons.NK_BUTTON_MAX)]; */
-		nk_mouse_button buttonLeft;
-		nk_mouse_button buttonMiddle;
-		nk_mouse_button buttonRight;
-		nk_mouse_button buttonDouble;
+		public nk_mouse_button buttonLeft;
+		public nk_mouse_button buttonMiddle;
+		public nk_mouse_button buttonRight;
+		public nk_mouse_button buttonDouble;
 
-		nk_vec2 pos;
-		nk_vec2 prev;
-		nk_vec2 delta;
-		nk_vec2 scroll_delta;
+		public nk_vec2 pos;
+		public nk_vec2 prev;
+		public nk_vec2 delta;
+		public nk_vec2 scroll_delta;
 
-		byte grab;
-		byte grabbed;
-		byte ungrab;
+		public byte grab;
+		public byte grabbed;
+		public byte ungrab;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_key {
-		int down;
-		uint clicked;
+		public int down;
+		public uint clicked;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_keyboard {
-		fixed uint keysCastTwoOfMeToOneNkKey[2 * (int)(nk_keys.NK_KEY_MAX)];
-		fixed byte text[16];
-		int text_len;
+		public fixed uint keysCastTwoOfMeToOneNkKey[2 * (int)(nk_keys.NK_KEY_MAX)];
+		public fixed byte text[16];
+		public int text_len;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_input {
-		nk_keyboard keyboard;
-		nk_mouse mouse;
+		public nk_keyboard keyboard;
+		public nk_mouse mouse;
 	}
 
 	// [DllImport(DllName, CallingConvention = CConv, CharSet = CSet)]

--- a/NuklearDotNet/Style.cs
+++ b/NuklearDotNet/Style.cs
@@ -14,306 +14,306 @@ namespace NuklearDotNet {
 	[StructLayout(LayoutKind.Explicit)]
 	public struct nk_style_item_data {
 		[FieldOffset(0)]
-		nk_image image;
+		public nk_image image;
 
 		[FieldOffset(0)]
-		nk_color color;
+		public nk_color color;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_item {
-		nk_style_item_type type;
-		nk_style_item_data data;
+		public nk_style_item_type type;
+		public nk_style_item_data data;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_text {
-		nk_color color;
-		nk_vec2 padding;
+		public nk_color color;
+		public nk_vec2 padding;
 	}
 
 	public unsafe delegate void nk_style_drawbeginend(nk_command_buffer* cbuf, nk_handle userdata);
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_button {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
 
-		nk_color text_background;
-		nk_color text_normal;
-		nk_color text_hover;
-		nk_color text_active;
-		uint text_alignment_nkflags;
+		public nk_color text_background;
+		public nk_color text_normal;
+		public nk_color text_hover;
+		public nk_color text_active;
+		public uint text_alignment_nkflags;
 
-		float border;
-		float rounding;
-		nk_vec2 padding;
-		nk_vec2 image_padding;
-		nk_vec2 touch_padding;
+		public float border;
+		public float rounding;
+		public nk_vec2 padding;
+		public nk_vec2 image_padding;
+		public nk_vec2 touch_padding;
 
-		nk_handle userdata;
-		IntPtr draw_begin_nkStyleDrawBeginEnd;
-		IntPtr draw_end_nkStyleDrawBeginEnd;
+		public nk_handle userdata;
+		public IntPtr draw_begin_nkStyleDrawBeginEnd;
+		public IntPtr draw_end_nkStyleDrawBeginEnd;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_toggle {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
 
-		nk_style_item cursor_normal;
-		nk_style_item cursor_hover;
+		public nk_style_item cursor_normal;
+		public nk_style_item cursor_hover;
 
-		nk_color text_normal;
-		nk_color text_hover;
-		nk_color text_active;
-		nk_color text_background;
-		uint text_alignment_nkflags;
+		public nk_color text_normal;
+		public nk_color text_hover;
+		public nk_color text_active;
+		public nk_color text_background;
+		public uint text_alignment_nkflags;
 
-		nk_vec2 padding;
-		nk_vec2 touch_padding;
-		float spacing;
-		float border;
+		public nk_vec2 padding;
+		public nk_vec2 touch_padding;
+		public float spacing;
+		public float border;
 
-		nk_handle userdata;
-		IntPtr draw_begin_nkStyleDrawBeginEnd;
-		IntPtr draw_end_nkStyleDrawBeginEnd;
+		public nk_handle userdata;
+		public IntPtr draw_begin_nkStyleDrawBeginEnd;
+		public IntPtr draw_end_nkStyleDrawBeginEnd;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_selectable {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item pressed;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item pressed;
 
-		nk_style_item normal_active;
-		nk_style_item hover_active;
-		nk_style_item pressed_active;
+		public nk_style_item normal_active;
+		public nk_style_item hover_active;
+		public nk_style_item pressed_active;
 
-		nk_color text_normal;
-		nk_color text_hover;
-		nk_color text_pressed;
+		public nk_color text_normal;
+		public nk_color text_hover;
+		public nk_color text_pressed;
 
-		nk_color text_normal_active;
-		nk_color text_hover_active;
-		nk_color text_pressed_active;
-		nk_color text_background;
-		uint text_alignment_nkflags;
+		public nk_color text_normal_active;
+		public nk_color text_hover_active;
+		public nk_color text_pressed_active;
+		public nk_color text_background;
+		public uint text_alignment_nkflags;
 
-		float rounding;
-		nk_vec2 padding;
-		nk_vec2 touch_padding;
-		nk_vec2 image_padding;
+		public float rounding;
+		public nk_vec2 padding;
+		public nk_vec2 touch_padding;
+		public nk_vec2 image_padding;
 
-		nk_handle userdata;
-		IntPtr draw_begin_nkStyleDrawBeginEnd;
-		IntPtr draw_end_nkStyleDrawBeginEnd;
+		public nk_handle userdata;
+		public IntPtr draw_begin_nkStyleDrawBeginEnd;
+		public IntPtr draw_end_nkStyleDrawBeginEnd;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_slider {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
 
-		nk_color bar_normal;
-		nk_color bar_hover;
-		nk_color bar_active;
-		nk_color bar_filled;
+		public nk_color bar_normal;
+		public nk_color bar_hover;
+		public nk_color bar_active;
+		public nk_color bar_filled;
 
-		nk_style_item cursor_normal;
-		nk_style_item cursor_hover;
-		nk_style_item cursor_active;
+		public nk_style_item cursor_normal;
+		public nk_style_item cursor_hover;
+		public nk_style_item cursor_active;
 
-		float border;
-		float rounding;
-		float bar_height;
-		nk_vec2 padding;
-		nk_vec2 spacing;
-		nk_vec2 cursor_size;
+		public float border;
+		public float rounding;
+		public float bar_height;
+		public nk_vec2 padding;
+		public nk_vec2 spacing;
+		public nk_vec2 cursor_size;
 
-		int show_buttons;
-		nk_style_button inc_button;
-		nk_style_button dec_button;
-		nk_symbol_type inc_symbol;
-		nk_symbol_type dec_symbol;
+		public int show_buttons;
+		public nk_style_button inc_button;
+		public nk_style_button dec_button;
+		public nk_symbol_type inc_symbol;
+		public nk_symbol_type dec_symbol;
 
-		nk_handle userdata;
-		IntPtr draw_begin_nkStyleDrawBeginEnd;
-		IntPtr draw_end_nkStyleDrawBeginEnd;
+		public nk_handle userdata;
+		public IntPtr draw_begin_nkStyleDrawBeginEnd;
+		public IntPtr draw_end_nkStyleDrawBeginEnd;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_progress {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
 
-		nk_style_item cursor_normal;
-		nk_style_item cursor_hover;
-		nk_style_item cursor_active;
-		nk_color cursor_border_color;
+		public nk_style_item cursor_normal;
+		public nk_style_item cursor_hover;
+		public nk_style_item cursor_active;
+		public nk_color cursor_border_color;
 
-		float rounding;
-		float border;
-		float cursor_border;
-		float cursor_rounding;
-		nk_vec2 padding;
+		public float rounding;
+		public float border;
+		public float cursor_border;
+		public float cursor_rounding;
+		public nk_vec2 padding;
 
-		nk_handle userdata;
-		IntPtr draw_begin_nkStyleDrawBeginEnd;
-		IntPtr draw_end_nkStyleDrawBeginEnd;
+		public nk_handle userdata;
+		public IntPtr draw_begin_nkStyleDrawBeginEnd;
+		public IntPtr draw_end_nkStyleDrawBeginEnd;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_scrollbar {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
 
-		nk_style_item cursor_normal;
-		nk_style_item cursor_hover;
-		nk_style_item cursor_active;
-		nk_color cursor_border_color;
+		public nk_style_item cursor_normal;
+		public nk_style_item cursor_hover;
+		public nk_style_item cursor_active;
+		public nk_color cursor_border_color;
 
-		float border;
-		float rounding;
-		float border_cursor;
-		float rounding_cursor;
-		nk_vec2 padding;
+		public float border;
+		public float rounding;
+		public float border_cursor;
+		public float rounding_cursor;
+		public nk_vec2 padding;
 
-		int show_buttons;
-		nk_style_button inc_button;
-		nk_style_button dec_button;
-		nk_symbol_type inc_symbol;
-		nk_symbol_type dec_symbol;
+		public int show_buttons;
+		public nk_style_button inc_button;
+		public nk_style_button dec_button;
+		public nk_symbol_type inc_symbol;
+		public nk_symbol_type dec_symbol;
 
-		nk_handle userdata;
-		IntPtr draw_begin_nkStyleDrawBeginEnd;
-		IntPtr draw_end_nkStyleDrawBeginEnd;
+		public nk_handle userdata;
+		public IntPtr draw_begin_nkStyleDrawBeginEnd;
+		public IntPtr draw_end_nkStyleDrawBeginEnd;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_edit {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
-		nk_style_scrollbar scrollbar;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
+		public nk_style_scrollbar scrollbar;
 
-		nk_color cursor_normal;
-		nk_color cursor_hover;
-		nk_color cursor_text_normal;
-		nk_color cursor_text_hover;
+		public nk_color cursor_normal;
+		public nk_color cursor_hover;
+		public nk_color cursor_text_normal;
+		public nk_color cursor_text_hover;
 
-		nk_color text_normal;
-		nk_color text_hover;
-		nk_color text_active;
+		public nk_color text_normal;
+		public nk_color text_hover;
+		public nk_color text_active;
 
-		nk_color selected_normal;
-		nk_color selected_hover;
-		nk_color selected_text_normal;
-		nk_color selected_text_hover;
+		public nk_color selected_normal;
+		public nk_color selected_hover;
+		public nk_color selected_text_normal;
+		public nk_color selected_text_hover;
 
-		float border;
-		float rounding;
-		float cursor_size;
-		nk_vec2 scrollbar_size;
-		nk_vec2 padding;
-		float row_padding;
+		public float border;
+		public float rounding;
+		public float cursor_size;
+		public nk_vec2 scrollbar_size;
+		public nk_vec2 padding;
+		public float row_padding;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_property {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
 
-		nk_color label_normal;
-		nk_color label_hover;
-		nk_color label_active;
+		public nk_color label_normal;
+		public nk_color label_hover;
+		public nk_color label_active;
 
-		nk_symbol_type sym_left;
-		nk_symbol_type sym_right;
+		public nk_symbol_type sym_left;
+		public nk_symbol_type sym_right;
 
-		float border;
-		float rounding;
-		nk_vec2 padding;
+		public float border;
+		public float rounding;
+		public nk_vec2 padding;
 
-		nk_style_edit edit;
-		nk_style_button inc_button;
-		nk_style_button dec_button;
+		public nk_style_edit edit;
+		public nk_style_button inc_button;
+		public nk_style_button dec_button;
 
-		nk_handle userdata;
-		IntPtr draw_begin_nkStyleDrawBeginEnd;
-		IntPtr draw_end_nkStyleDrawBeginEnd;
+		public nk_handle userdata;
+		public IntPtr draw_begin_nkStyleDrawBeginEnd;
+		public IntPtr draw_end_nkStyleDrawBeginEnd;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_chart {
-		nk_style_item background;
-		nk_color border_color;
-		nk_color selected_color;
-		nk_color color;
+		public nk_style_item background;
+		public nk_color border_color;
+		public nk_color selected_color;
+		public nk_color color;
 
-		float border;
-		float rounding;
-		nk_vec2 padding;
+		public float border;
+		public float rounding;
+		public nk_vec2 padding;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_combo {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
-		nk_color border_color;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
+		public nk_color border_color;
 
-		nk_color label_normal;
-		nk_color label_hover;
-		nk_color label_active;
+		public nk_color label_normal;
+		public nk_color label_hover;
+		public nk_color label_active;
 
-		nk_color symbol_normal;
-		nk_color symbol_hover;
-		nk_color symbol_active;
+		public nk_color symbol_normal;
+		public nk_color symbol_hover;
+		public nk_color symbol_active;
 
-		nk_style_button button;
-		nk_symbol_type sym_normal;
-		nk_symbol_type sym_hover;
-		nk_symbol_type sym_active;
+		public nk_style_button button;
+		public nk_symbol_type sym_normal;
+		public nk_symbol_type sym_hover;
+		public nk_symbol_type sym_active;
 
-		float border;
-		float rounding;
-		nk_vec2 content_padding;
-		nk_vec2 button_padding;
-		nk_vec2 spacing;
+		public float border;
+		public float rounding;
+		public nk_vec2 content_padding;
+		public nk_vec2 button_padding;
+		public nk_vec2 spacing;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_tab {
-		nk_style_item background;
-		nk_color border_color;
-		nk_color text;
+		public nk_style_item background;
+		public nk_color border_color;
+		public nk_color text;
 
-		nk_style_button tab_maximize_button;
-		nk_style_button tab_minimize_button;
-		nk_style_button node_maximize_button;
-		nk_style_button node_minimize_button;
-		nk_symbol_type sym_minimize;
-		nk_symbol_type sym_maximize;
+		public nk_style_button tab_maximize_button;
+		public nk_style_button tab_minimize_button;
+		public nk_style_button node_maximize_button;
+		public nk_style_button node_minimize_button;
+		public nk_symbol_type sym_minimize;
+		public nk_symbol_type sym_maximize;
 
-		float border;
-		float rounding;
-		float indent;
-		nk_vec2 padding;
-		nk_vec2 spacing;
+		public float border;
+		public float rounding;
+		public float indent;
+		public nk_vec2 padding;
+		public nk_vec2 spacing;
 	}
 
 	public enum nk_style_header_align {
@@ -323,98 +323,98 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_window_header {
-		nk_style_item normal;
-		nk_style_item hover;
-		nk_style_item active;
+		public nk_style_item normal;
+		public nk_style_item hover;
+		public nk_style_item active;
 
-		nk_style_button close_button;
-		nk_style_button minimize_button;
-		nk_symbol_type close_symbol;
-		nk_symbol_type minimize_symbol;
-		nk_symbol_type maximize_symbol;
+		public nk_style_button close_button;
+		public nk_style_button minimize_button;
+		public nk_symbol_type close_symbol;
+		public nk_symbol_type minimize_symbol;
+		public nk_symbol_type maximize_symbol;
 
-		nk_color label_normal;
-		nk_color label_hover;
-		nk_color label_active;
+		public nk_color label_normal;
+		public nk_color label_hover;
+		public nk_color label_active;
 
-		nk_style_header_align align;
-		nk_vec2 padding;
-		nk_vec2 label_padding;
-		nk_vec2 spacing;
+		public nk_style_header_align align;
+		public nk_vec2 padding;
+		public nk_vec2 label_padding;
+		public nk_vec2 spacing;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_style_window {
-		nk_style_window_header header;
-		nk_style_item fixed_background;
-		nk_color background;
+		public nk_style_window_header header;
+		public nk_style_item fixed_background;
+		public nk_color background;
 
-		nk_color border_color;
-		nk_color popup_border_color;
-		nk_color combo_border_color;
-		nk_color contextual_border_color;
-		nk_color menu_border_color;
-		nk_color group_border_color;
-		nk_color tooltip_border_color;
-		nk_style_item scaler;
+		public nk_color border_color;
+		public nk_color popup_border_color;
+		public nk_color combo_border_color;
+		public nk_color contextual_border_color;
+		public nk_color menu_border_color;
+		public nk_color group_border_color;
+		public nk_color tooltip_border_color;
+		public nk_style_item scaler;
 
-		float border;
-		float combo_border;
-		float contextual_border;
-		float menu_border;
-		float group_border;
-		float tooltip_border;
-		float popup_border;
-		float min_row_height_padding;
+		public float border;
+		public float combo_border;
+		public float contextual_border;
+		public float menu_border;
+		public float group_border;
+		public float tooltip_border;
+		public float popup_border;
+		public float min_row_height_padding;
 
-		float rounding;
-		nk_vec2 spacing;
-		nk_vec2 scrollbar_size;
-		nk_vec2 min_size;
+		public float rounding;
+		public nk_vec2 spacing;
+		public nk_vec2 scrollbar_size;
+		public nk_vec2 min_size;
 
-		nk_vec2 padding;
-		nk_vec2 group_padding;
-		nk_vec2 popup_padding;
-		nk_vec2 combo_padding;
-		nk_vec2 contextual_padding;
-		nk_vec2 menu_padding;
-		nk_vec2 tooltip_padding;
+		public nk_vec2 padding;
+		public nk_vec2 group_padding;
+		public nk_vec2 popup_padding;
+		public nk_vec2 combo_padding;
+		public nk_vec2 contextual_padding;
+		public nk_vec2 menu_padding;
+		public nk_vec2 tooltip_padding;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_style {
-		nk_user_font* font;
+		public nk_user_font* font;
 
 		/* fixed nk_cursor* cursors[(int)(nk_style_cursor.NK_CURSOR_COUNT)]; */
-		nk_cursor* cursorArrow;
-		nk_cursor* cursorText;
-		nk_cursor* cursorMove;
-		nk_cursor* cursorResizeV;
-		nk_cursor* cursorResizeH;
-		nk_cursor* cursorResizeTLDR;
-		nk_cursor* cursorResizeTRDL;
+		public nk_cursor* cursorArrow;
+		public nk_cursor* cursorText;
+		public nk_cursor* cursorMove;
+		public nk_cursor* cursorResizeV;
+		public nk_cursor* cursorResizeH;
+		public nk_cursor* cursorResizeTLDR;
+		public nk_cursor* cursorResizeTRDL;
 
-		nk_cursor* cursor_active;
-		nk_cursor* cursor_last;
-		int cursor_visible;
+		public nk_cursor* cursor_active;
+		public nk_cursor* cursor_last;
+		public int cursor_visible;
 
-		nk_style_text text;
-		nk_style_button button;
-		nk_style_button contextual_button;
-		nk_style_button menu_button;
-		nk_style_toggle option;
-		nk_style_toggle checkbox;
-		nk_style_selectable selectable;
-		nk_style_slider slider;
-		nk_style_progress progress;
-		nk_style_property property;
-		nk_style_edit edit;
-		nk_style_chart chart;
-		nk_style_scrollbar scrollh;
-		nk_style_scrollbar scrollb;
-		nk_style_tab tab;
-		nk_style_combo combo;
-		nk_style_window window;
+		public nk_style_text text;
+		public nk_style_button button;
+		public nk_style_button contextual_button;
+		public nk_style_button menu_button;
+		public nk_style_toggle option;
+		public nk_style_toggle checkbox;
+		public nk_style_selectable selectable;
+		public nk_style_slider slider;
+		public nk_style_progress progress;
+		public nk_style_property property;
+		public nk_style_edit edit;
+		public nk_style_chart chart;
+		public nk_style_scrollbar scrollh;
+		public nk_style_scrollbar scrollb;
+		public nk_style_tab tab;
+		public nk_style_combo combo;
+		public nk_style_window window;
 	}
 
 	public enum nk_style_colors {

--- a/NuklearDotNet/Text.cs
+++ b/NuklearDotNet/Text.cs
@@ -8,34 +8,34 @@ using System.Threading.Tasks;
 namespace NuklearDotNet {
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_str {
-		nk_buffer buffer;
-		int len;
+		public nk_buffer buffer;
+		public int len;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_clipboard {
-		nk_handle userdata;
-		IntPtr pastefun_nkPluginPasteT;
-		IntPtr copyfun_nkPluginCopyT;
+		public nk_handle userdata;
+		public IntPtr pastefun_nkPluginPasteT;
+		public IntPtr copyfun_nkPluginCopyT;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_text_undo_record {
-		int iwhere;
-		short insert_length;
-		short delete_length;
-		short char_storage;
+		public int iwhere;
+		public short insert_length;
+		public short delete_length;
+		public short char_storage;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_text_undo_state {
 		// fixed nk_text_undo_record undo_rec[99];
-		fixed short undo_rec_nkTextUndoRecord[99 * 6]; // ...?
-		fixed uint undo_char[999];
-		short undo_point;
-		short redo_point;
-		short undo_char_point;
-		short redo_char_point;
+		public fixed short undo_rec_nkTextUndoRecord[99 * 6]; // ...?
+		public fixed uint undo_char[999];
+		public short undo_point;
+		public short redo_point;
+		public short undo_char_point;
+		public short redo_char_point;
 	}
 
 	public enum nk_text_edit_type {
@@ -51,23 +51,23 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_text_edit {
-		nk_clipboard clip;
-		nk_str str;
-		IntPtr filter_nkPluginFilterT;
-		nk_vec2 scrollbar;
+		public nk_clipboard clip;
+		public nk_str str;
+		public IntPtr filter_nkPluginFilterT;
+		public nk_vec2 scrollbar;
 
-		int cursor;
-		int select_start;
-		int select_end;
-		byte mode;
-		byte cursor_at_end_of_line;
-		byte initialized;
-		byte has_preferred_x;
-		byte single_line;
-		byte active;
-		byte padding1;
-		float preferred_x;
-		nk_text_undo_state undo;
+		public int cursor;
+		public int select_start;
+		public int select_end;
+		public byte mode;
+		public byte cursor_at_end_of_line;
+		public byte initialized;
+		public byte has_preferred_x;
+		public byte single_line;
+		public byte active;
+		public byte padding1;
+		public float preferred_x;
+		public nk_text_undo_state undo;
 	}
 
 	// [DllImport(DllName, CallingConvention = CConv, CharSet = CSet)]

--- a/NuklearDotNet/Widget.cs
+++ b/NuklearDotNet/Widget.cs
@@ -40,28 +40,28 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_chart_slot {
-		nk_chart_type type;
-		nk_color color;
-		nk_color highlight;
-		float min;
-		float max;
-		float range;
-		int count;
-		nk_vec2 last;
-		int index;
+		public nk_chart_type type;
+		public nk_color color;
+		public nk_color highlight;
+		public float min;
+		public float max;
+		public float range;
+		public int count;
+		public nk_vec2 last;
+		public int index;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_chart {
-		int slot;
-		float x;
-		float y;
-		float w;
-		float h;
-		nk_chart_slot slot0;
-		nk_chart_slot slot1;
-		nk_chart_slot slot2;
-		nk_chart_slot slot3;
+		public int slot;
+		public float x;
+		public float y;
+		public float w;
+		public float h;
+		public nk_chart_slot slot0;
+		public nk_chart_slot slot1;
+		public nk_chart_slot slot2;
+		public nk_chart_slot slot3;
 	}
 
 	public enum nk_panel_row_layout_type {
@@ -79,59 +79,59 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_row_layout {
-		nk_panel_row_layout_type type;
-		int index;
-		float height;
-		float min_height;
-		int columns;
-		float* ratio;
-		float item_width;
-		float item_height;
-		float item_offset;
-		float filled;
-		nk_rect item;
-		int tree_depth;
-		fixed float templates[16];
+		public nk_panel_row_layout_type type;
+		public int index;
+		public float height;
+		public float min_height;
+		public int columns;
+		public float* ratio;
+		public float item_width;
+		public float item_height;
+		public float item_offset;
+		public float filled;
+		public nk_rect item;
+		public int tree_depth;
+		public fixed float templates[16];
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_popup_buffer {
-		IntPtr begin_nksize;
-		IntPtr parent_nksize;
-		IntPtr last_nksize;
-		IntPtr end_nksize;
-		int active;
+		public IntPtr begin_nksize;
+		public IntPtr parent_nksize;
+		public IntPtr last_nksize;
+		public IntPtr end_nksize;
+		public int active;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_menu_state {
-		float x;
-		float y;
-		float w;
-		float h;
-		nk_scroll offset;
+		public float x;
+		public float y;
+		public float w;
+		public float h;
+		public nk_scroll offset;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_panel {
-		nk_panel_type type;
-		uint flags_nkflags;
-		nk_rect bounds;
-		uint* offset_x;
-		uint* offset_y;
-		float at_x;
-		float at_y;
-		float max_x;
-		float footer_height;
-		float header_height;
-		float border;
-		uint has_scrolling;
-		nk_rect clip;
-		nk_menu_state menu;
-		nk_row_layout row;
-		nk_chart chart;
-		nk_command_buffer* buffer;
-		nk_panel* parent;
+		public nk_panel_type type;
+		public uint flags_nkflags;
+		public nk_rect bounds;
+		public uint* offset_x;
+		public uint* offset_y;
+		public float at_x;
+		public float at_y;
+		public float max_x;
+		public float footer_height;
+		public float header_height;
+		public float border;
+		public uint has_scrolling;
+		public nk_rect clip;
+		public nk_menu_state menu;
+		public nk_row_layout row;
+		public nk_chart chart;
+		public nk_command_buffer* buffer;
+		public nk_panel* parent;
 	}
 
 	[Flags]
@@ -148,84 +148,84 @@ namespace NuklearDotNet {
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_popup_state {
-		nk_window* win;
-		nk_panel_type type;
-		nk_popup_buffer buf;
-		uint name_nkhash;
-		int active;
-		uint combo_count;
-		uint con_count;
-		uint con_old;
-		uint active_con;
-		nk_rect header;
+		public nk_window* win;
+		public nk_panel_type type;
+		public nk_popup_buffer buf;
+		public uint name_nkhash;
+		public int active;
+		public uint combo_count;
+		public uint con_count;
+		public uint con_old;
+		public uint active_con;
+		public nk_rect header;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct nk_edit_state {
-		uint name_nkhash;
-		uint seq;
-		uint old;
-		int active;
-		int prev;
-		int cursor;
-		int sel_start;
-		int sel_end;
-		nk_scroll scrollbar;
-		byte mode;
-		byte single_line;
+		public uint name_nkhash;
+		public uint seq;
+		public uint old;
+		public int active;
+		public int prev;
+		public int cursor;
+		public int sel_start;
+		public int sel_end;
+		public nk_scroll scrollbar;
+		public byte mode;
+		public byte single_line;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_property_state {
-		int active;
-		int prev;
-		fixed byte buffer[64];
-		int length;
-		int cursor;
-		int select_start;
-		int select_end;
-		uint name_nkhash;
-		uint seq;
-		uint old;
-		int state;
+		public int active;
+		public int prev;
+		public fixed byte buffer[64];
+		public int length;
+		public int cursor;
+		public int select_start;
+		public int select_end;
+		public uint name_nkhash;
+		public uint seq;
+		public uint old;
+		public int state;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_window {
-		uint seq;
-		uint name_nkhash;
-		fixed byte name_string[64];
-		uint flags_nkflags;
+		public uint seq;
+		public uint name_nkhash;
+		public fixed byte name_string[64];
+		public uint flags_nkflags;
 
-		nk_rect bounds;
-		nk_scroll scrollbar;
-		nk_command_buffer buffer;
-		nk_panel* layout;
-		float scrollbar_hiding_timer;
+		public nk_rect bounds;
+		public nk_scroll scrollbar;
+		public nk_command_buffer buffer;
+		public nk_panel* layout;
+		public float scrollbar_hiding_timer;
 
-		nk_property_state property;
-		nk_popup_state popup;
-		nk_edit_state edit;
-		uint scrolled;
+		public nk_property_state property;
+		public nk_popup_state popup;
+		public nk_edit_state edit;
+		public uint scrolled;
 
-		nk_table* tables;
-		uint table_count;
+		public nk_table* tables;
+		public uint table_count;
 
-		nk_window* next;
-		nk_window* prev;
-		nk_window* parent;
+		public nk_window* next;
+		public nk_window* prev;
+		public nk_window* parent;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct nk_list_view {
-		int begin;
-		int end;
-		int count;
+		public int begin;
+		public int end;
+		public int count;
 
-		int total_height;
-		nk_context* ctx;
-		uint* scroll_pointer;
-		uint scroll_value;
+		public int total_height;
+		public nk_context* ctx;
+		public uint* scroll_pointer;
+		public uint scroll_value;
 	}
 
 	public enum nk_widget_layout_states {


### PR DESCRIPTION
Make all struct fields public (except for that one padding field). Sorry, I forgot that struct visibility was private by default when I was doing NuklearSharp.

Here's the grunt work of making stuff public.

Keep up the great work!