### PR TITLE
Put bigger fields later in unions

### DIFF
--- a/NuklearDotNet/General.cs
+++ b/NuklearDotNet/General.cs
@@ -76,9 +76,9 @@ namespace NuklearDotNet {
 	[StructLayout(LayoutKind.Explicit)]
 	public struct nk_handle {
 		[FieldOffset(0)]
-		public IntPtr ptr;
-		[FieldOffset(0)]
 		public int id;
+		[FieldOffset(0)]
+		public IntPtr ptr;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]

--- a/NuklearDotNet/Init.cs
+++ b/NuklearDotNet/Init.cs
@@ -339,11 +339,11 @@ namespace NuklearDotNet {
 	[StructLayout(LayoutKind.Explicit)]
 	public unsafe struct nk_page_data {
 		[FieldOffset(0)]
-		public nk_table tbl;
-		[FieldOffset(0)]
 		public nk_panel pan;
 		[FieldOffset(0)]
 		public nk_window win;
+		[FieldOffset(0)]
+		public nk_table tbl;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]

--- a/NuklearDotNet/Style.cs
+++ b/NuklearDotNet/Style.cs
@@ -14,10 +14,10 @@ namespace NuklearDotNet {
 	[StructLayout(LayoutKind.Explicit)]
 	public struct nk_style_item_data {
 		[FieldOffset(0)]
-		public nk_image image;
+		public nk_color color;
 
 		[FieldOffset(0)]
-		public nk_color color;
+		public nk_image image;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Per http://yizhang82.me/pinvoke-union, (at least some) .NET Framework
versions work on structs with Explicit layouts with everything at
FieldOffset(0) (i.e. unions) by copying each field one at a time.

That means that if you have a smaller field after a big one, things can
get trashed.

For safety, put the biggest fields at the end of each union.